### PR TITLE
Fix script execution when piped and make script POSIX-compliant

### DIFF
--- a/src/public/index.sh
+++ b/src/public/index.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 
 ##
@@ -54,11 +54,11 @@ decolor() {
 
 log_trace() {
   if (( ${LOG_TRACE:-0} )); then
-    printf "%b ${I_DIM}%s${I_RESET}\n" "${C_PURPLE}T${C_RESET}" "$(decolor <<< "$*")" >&2
+    printf "%b ${I_DIM}%s${I_RESET}\n" "${C_PURPLE}T${C_RESET}" "$(printf "%s" "$*" | decolor)" >&2
   fi
 }
 log_dry_run() {
-  printf "${I_DIM}%b %s${I_RESET}\n" "${C_YELLOW}dry_run:${C_RESET}" "$(decolor <<< "$*")" >&2
+  printf "${I_DIM}%b %s${I_RESET}\n" "${C_YELLOW}dry_run:${C_RESET}" "$(printf "%s" "$*" | decolor)" >&2
 }
 log_debug() {
   printf "%b %s\n" "${C_YELLOW}D${C_RESET}" "$*" >&2
@@ -67,14 +67,14 @@ log_info() {
   printf "${I_BOLD}%b %s${I_RESET}\n" "${C_BLUE}i${C_RESET}" "$*"
 }
 log_warn() {
-  printf "${I_BOLD}%b ${C_YELLOW}%s${C_RESET}${I_RESET}\n" "${C_YELLOW}W${C_RESET}" "$(decolor <<< "$*")" >&2
+  printf "${I_BOLD}%b ${C_YELLOW}%s${C_RESET}${I_RESET}\n" "${C_YELLOW}W${C_RESET}" "$(printf "%s" "$*" | decolor)" >&2
 }
 log_error() {
-  printf "${I_BOLD}%b ${C_RED}%s${C_RESET}${I_RESET}\n" "${C_RED}E${C_RESET}" "$(decolor <<< "$*")" >&2
+  printf "${I_BOLD}%b ${C_RED}%s${C_RESET}${I_RESET}\n" "${C_RED}E${C_RESET}" "$(printf "%s" "$*" | decolor)" >&2
 }
 
 log_success() {
-  printf "${I_BOLD}%b ${C_GREEN}%s${C_RESET}${I_RESET}\n" "${C_GREEN}\u2713${C_RESET}" "$(decolor <<< "$*")"
+  printf "${I_BOLD}%b ${C_GREEN}%s${C_RESET}${I_RESET}\n" "${C_GREEN}\u2713${C_RESET}" "$(printf "%s" "$*" | decolor)"
 }
 log_task_success() {
   printf "%b %s\n" "${C_GREEN}\u00B7${C_RESET}" "$*"
@@ -93,7 +93,7 @@ log_question_inline() {
 }
 
 format_code() {
-  printf "${C_CYAN}${I_DIM}\`${I_RESET}%s${I_DIM}\`${I_RESET}${C_RESET}" "$(decolor <<< "$*")"
+  printf "${C_CYAN}${I_DIM}\`${I_RESET}%s${I_DIM}\`${I_RESET}${C_RESET}" "$(printf "%s" "$*" | decolor)"
 }
 format_hyperlink() {
   local text="${1:?"Expected hyperlink text"}"

--- a/src/public/index.sh
+++ b/src/public/index.sh
@@ -171,7 +171,7 @@ edo() {
   else
     log_trace "$*"
     # NOTE: `$@`, `"$@"` or `eval $@` would break spaces in arguments.
-    eval $(printf '%q ' "$@" | sed "${REGEX_ALLOW_PIPES:?}" | sed -E "${REGEX_ALLOW_REDIRECTS:?}")
+    eval $(printf '%q ' "$@" | sed "${REGEX_ALLOW_PIPES:?}" | sed -E "${REGEX_ALLOW_REDIRECTS:?}") < /dev/tty > /dev/tty
   fi
   status=$?
   return $status

--- a/src/public/index.sh
+++ b/src/public/index.sh
@@ -12,7 +12,6 @@
 
 
 set -eu
-set -o pipefail
 
 
 # ===== Colors and style =====


### PR DESCRIPTION
My bad, the shebang wasn’t interpreted when running `curl -L https://get.prose.org | sh`. This means on distributions where `sh` is not an alias for `bash`, the script would fail.

---

Also, running `curl -L https://get.prose.org | bash` would just say:

```log
i Hello and welcome to the Prose installer script.

? What is the name of your company? ? What is your apex domain? main: line 358: APEX_DOMAIN: parameter null or not set
(exit 1)
```

because the script would read from stdin but it’s piped so it would just skip `read`s. That was a subtle catch I did not expect.